### PR TITLE
API-provider

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,0 +1,12 @@
+import os
+from fastapi import Header, HTTPException
+
+def verify_groq_api_key(x_groq_api_key: str = Header(..., description="Clave de API de Groq válida (gsk_...)")) -> str:
+    """Valida la estructura de la API key e inyecta la credencial en el entorno."""
+    if not x_groq_api_key.startswith("gsk_"):
+        raise HTTPException(
+            status_code=401, 
+            detail="La cabecera 'X-Groq-API-Key' provista no es una clave válida."
+        )
+    os.environ["GROQ_API_KEY"] = x_groq_api_key
+    return x_groq_api_key

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,94 @@
+from fastapi import FastAPI, Depends, File, UploadFile, Query, HTTPException
+from fastapi.responses import FileResponse
+
+# Componentes de arquitectura de la API
+from api.schemas import TranslationRequest
+from api.dependencies import verify_groq_api_key
+
+# Capa de Servicio descentralizada (Lógica de Negocio)
+from api.services import process_single_java_file, process_zip_batch
+from java_translator.translator import translate_code, build_polyglot_wrapper
+
+app = FastAPI(
+    title="B4B3L - Polyglot & Standard Translator API",
+    version="1.0.0",
+    description = """
+API del motor **B4B3L** para la traducción avanzada de código Java.
+
+### 🌐 Endpoints Disponibles
+* **Texto (`/text`):** Traduce cadenas de código Java enviadas en formato JSON.
+* **Archivos/Lotes (`/file`):** Traduce archivos individuales `.java` o carpetas completas en lotes mediante archivos `.zip` (preservando la estructura original).
+
+### 🔄 Modos de Operación
+* `standard`: Devuelve el código limpio traducido directamente al lenguaje destino (`python` o `javascript`).
+* `polyglot`: Devuelve una clase ejecutable Java híbrida estructurada para el entorno **GraalVM Polyglot API**.
+
+⚠️ *Requiere autenticación mediante la cabecera **X-Groq-API-Key**.*
+""",
+    swagger_ui_parameters={"defaultModelsExpandDepth": -1}
+)
+
+# TRADUCCIÓN POR TEXTO (JSON)
+@app.post("/api/v1/translate/text", tags=["Main"])
+async def translate_text_endpoint(
+    request: TranslationRequest, 
+    _apiKey: str = Depends(verify_groq_api_key)
+):
+    if request.mode not in ["standard", "polyglot"]:
+        raise HTTPException(status_code=400, detail="El parámetro 'mode' debe ser 'standard' o 'polyglot'.")
+    
+    try:
+        translation_result = translate_code(request.code, request.target_language)
+        raw_code = translation_result["code"]
+        
+        if request.mode == "polyglot":
+            final_code = build_polyglot_wrapper("ClaseDinamica", request.target_language, raw_code)
+            lang_returned = "java"
+        else:
+            final_code = raw_code
+            lang_returned = request.target_language
+
+        return {
+            "status": "success",
+            "mode": request.mode,
+            "target_language": lang_returned,
+            "translated_code": final_code,
+            "tokens": translation_result["tokens"]
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+# TRADUCCIÓN POR ARCHIVOS (.JAVA O .ZIP)
+@app.post("/api/v1/translate/file", tags=["Main"])
+async def translate_file_endpoint(
+    target_language: str,
+    mode: str = Query("standard", regex="^(standard|polyglot)$"),
+    file: UploadFile = File(...),
+    _apiKey: str = Depends(verify_groq_api_key)
+):
+    filename = file.filename
+
+    # --- CASO A: ARCHIVO ÚNICO .JAVA ---
+    if filename.endswith(".java"):
+        try:
+            file_path, out_name, media_type = await process_single_java_file(file, target_language, mode)
+            return FileResponse(path=file_path, filename=out_name, media_type=media_type)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Error traduciendo archivo Java: {str(e)}")
+
+    # --- CASO B: PROCESAMIENTO POR LOTES (.ZIP) ---
+    elif filename.endswith(".zip"):
+        try:
+            zip_out_path = await process_zip_batch(file, target_language, mode)
+            return FileResponse(
+                path=zip_out_path, 
+                filename=f"lote_{mode}_{target_language}.zip", 
+                media_type="application/zip"
+            )
+        except HTTPException as he:
+            raise he
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Error en procesamiento por lote: {str(e)}")
+
+    else:
+        raise HTTPException(status_code=400, detail="Formato de archivo inválido. Utilice un archivo '.java' o un '.zip'.")

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, Field
+
+class TranslationRequest(BaseModel):
+    code: str = Field(..., description="Código fuente Java a traducir")
+    target_language: str = Field(..., description="Lenguaje destino ('python' o 'javascript')")
+    mode: str = Field("standard", description="Modo de traducción: 'standard' o 'polyglot'")

--- a/api/services.py
+++ b/api/services.py
@@ -1,0 +1,106 @@
+import os
+import shutil
+import zipfile
+from pathlib import Path
+from fastapi import UploadFile, HTTPException
+
+# Importamos las herramientas del traductor core
+from java_translator.translator import translate_code, build_polyglot_wrapper
+
+TMP_DIR = Path("/tmp/b4b3l_api")
+TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+def get_file_extension(target_language: str) -> str:
+    """Retorna la extensión adecuada según el lenguaje destino."""
+    return ".py" if target_language.lower() == "python" else ".js"
+
+
+async def process_single_java_file(file: UploadFile, target_language: str, mode: str) -> tuple[Path, str, str]:
+    """
+    Procesa, traduce y empaqueta un único archivo .java.
+    Retorna una tupla con: (ruta_del_archivo_temporal, nombre_salida, media_type)
+    """
+    class_name = Path(file.filename).stem
+    content = await file.read()
+    
+    # Traducción
+    translation_result = translate_code(content.decode("utf-8"), target_language)
+    raw_code = translation_result["code"]
+    
+    if mode == "polyglot":
+        codigo_final = build_polyglot_wrapper(class_name, target_language, raw_code)
+        output_filename = f"{class_name}Poliglota.java"
+        media_type = "text/x-java-source"
+    else:
+        codigo_final = raw_code
+        output_filename = f"{class_name}{get_file_extension(target_language)}"
+        media_type = "text/plain"
+    
+    tmp_output_path = TMP_DIR / output_filename
+    tmp_output_path.write_text(codigo_final, encoding="utf-8")
+    
+    return tmp_output_path, output_filename, media_type
+
+
+async def process_zip_batch(file: UploadFile, target_language: str, mode: str) -> Path:
+    """
+    Descomprime un archivo ZIP, traduce todos los archivos .java internos
+    respetando el árbol de directorios y empaqueta el resultado en un nuevo ZIP.
+    Retorna la ruta del archivo ZIP resultante.
+    """
+    upload_id = os.urandom(4).hex()
+    extract_dir = TMP_DIR / f"extract_{upload_id}"
+    output_dir = TMP_DIR / f"output_{upload_id}"
+    extract_dir.mkdir()
+    output_dir.mkdir()
+
+    zip_in_path = TMP_DIR / f"{upload_id}_{file.filename}"
+    zip_out_path = TMP_DIR / f"resultado_{upload_id}.zip"
+
+    try:
+        # Guardar ZIP entrante
+        with open(zip_in_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+
+        # Extraer contenido
+        with zipfile.ZipFile(zip_in_path, 'r') as zip_ref:
+            zip_ref.extractall(extract_dir)
+
+        java_files = list(extract_dir.glob("**/*.java"))
+        if not java_files:
+            raise HTTPException(status_code=400, detail="No hay archivos .java dentro del archivo ZIP provisto.")
+
+        # Procesar lote iterativamente
+        for java_file_path in java_files:
+            class_name = java_file_path.stem
+            java_code = java_file_path.read_text(encoding="utf-8")
+            
+            translation_result = translate_code(java_code, target_language)
+            raw_code = translation_result["code"]
+            
+            if mode == "polyglot":
+                codigo_final = build_polyglot_wrapper(class_name, target_language, raw_code)
+                new_name = f"{class_name}Poliglota.java"
+            else:
+                codigo_final = raw_code
+                new_name = f"{class_name}{get_file_extension(target_language)}"
+            
+            # Replicar la estructura de carpetas original en el output
+            relative_path = java_file_path.relative_to(extract_dir)
+            out_file_path = (output_dir / relative_path).with_name(new_name)
+            out_file_path.parent.mkdir(parents=True, exist_ok=True)
+            out_file_path.write_text(codigo_final, encoding="utf-8")
+
+        # Comprimir resultados
+        with zipfile.ZipFile(zip_out_path, 'w', zipfile.ZIP_DEFLATED) as zip_out:
+            for file_to_zip in output_dir.glob("**/*"):
+                if file_to_zip.is_file():
+                    zip_out.write(file_to_zip, file_to_zip.relative_to(output_dir))
+
+        return zip_out_path
+
+    finally:
+        # Limpieza absoluta de temporales locales de este hilo/petición
+        if extract_dir.exists(): shutil.rmtree(extract_dir)
+        if output_dir.exists(): shutil.rmtree(output_dir)
+        if zip_in_path.exists(): os.remove(zip_in_path)


### PR DESCRIPTION
Estructura del API: Centralicé toda la lógica dentro de la carpeta api/ usando FastAPI. Quedaron listos los endpoints base para interactuar con el traductor de forma limpia.

Modos Soportados: Ya se pueden realizar peticiones tanto en modo standard (traducción directa de código) como en modo polyglot (para el flujo dinámico con GraalVM).

Seguridad en Headers: Se configuró para que el cliente tenga que enviar obligatoriamente la clave del modelo mediante la cabecera X-Groq-API-Key, protegiendo el backend.

Documentación: El servidor ya levanta sin problemas con Uvicorn y expone la documentación interactiva de Swagger en /docs para probar los payloads de forma rápida.

Quedo atento a la revisión por si hay que pulir algún detalle antes del merge. Saludos!