### PR TITLE
Fix/standard mode clean output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .venv/
 venv/
 env/
-**/__pycache__/
+__pycache__/
 *.pyc
 .git/
 .env

--- a/api/main.py
+++ b/api/main.py
@@ -1,77 +1,44 @@
-from fastapi import FastAPI, Depends, File, UploadFile, Query, HTTPException, Header
+from fastapi import FastAPI, Depends, File, UploadFile, Query, HTTPException
 from fastapi.responses import FileResponse
-from fastapi.middleware.cors import CORSMiddleware
 
 # Componentes de arquitectura de la API
 from api.schemas import TranslationRequest
+from api.dependencies import verify_groq_api_key
 
 # Capa de Servicio descentralizada (Lógica de Negocio)
 from api.services import process_single_java_file, process_zip_batch
 from java_translator.translator import translate_code, build_polyglot_wrapper
 
-# Dependencia unificada: Ahora genera UN SOLO input limpio en Swagger
-async def get_api_key(
-    x_api_key: str = Header(None, alias="X-API-Key")
-):
-    if not x_api_key:
-        raise HTTPException(
-            status_code=401, 
-            detail="Falta credencial de autenticación. Incluya la cabecera 'X-API-Key'."
-        )
-    return x_api_key
-
 app = FastAPI(
-    title="B4B3L - Polyglot & Multi-Provider Standard Translator API",
-    version="1.1.0",
+    title="B4B3L - Polyglot & Standard Translator API",
+    version="1.0.0",
     description = """
-API del motor **B4B3L** para la traducción avanzada de código Java con soporte multi-proveedor.
+API del motor **B4B3L** para la traducción avanzada de código Java.
 
 ### 🌐 Endpoints Disponibles
 * **Texto (`/text`):** Traduce cadenas de código Java enviadas en formato JSON.
-* **Archivos/Lotes (`/file`):** Traduce archivos individuales `.java` o carpetas completas en lotes mediante archivos `.zip`.
+* **Archivos/Lotes (`/file`):** Traduce archivos individuales `.java` o carpetas completas en lotes mediante archivos `.zip` (preservando la estructura original).
 
 ### 🔄 Modos de Operación
 * `standard`: Devuelve el código limpio traducido directamente al lenguaje destino (`python` o `javascript`).
 * `polyglot`: Devuelve una clase ejecutable Java híbrida estructurada para el entorno **GraalVM Polyglot API**.
 
-⚠️ *Requieres autenticación mediante la cabecera **X-API-Key** (acepta tokens de Groq, OpenAI, Gemini y Anthropic).*
+⚠️ *Requiere autenticación mediante la cabecera **X-Groq-API-Key**.*
 """,
     swagger_ui_parameters={"defaultModelsExpandDepth": -1}
 )
-
-# CORS
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# RUTA DE PRUEBA (HEALTH CHECK)
-@app.get("/", tags=["Health Check"])
-async def root():
-    return {
-        "status": "success",
-        "message": "API de B4B3L en linea",
-    }
 
 # TRADUCCIÓN POR TEXTO (JSON)
 @app.post("/api/v1/translate/text", tags=["Main"])
 async def translate_text_endpoint(
     request: TranslationRequest, 
-    api_key: str = Depends(get_api_key)
+    _apiKey: str = Depends(verify_groq_api_key)
 ):
     if request.mode not in ["standard", "polyglot"]:
         raise HTTPException(status_code=400, detail="El parámetro 'mode' debe ser 'standard' o 'polyglot'.")
     
     try:
-        # Pasamos la api_key dinámicamente al traductor polimórfico
-        translation_result = translate_code(request.code, request.target_language, api_key=api_key)
-        
-        if "error" in translation_result:
-            raise HTTPException(status_code=400, detail=translation_result["error"])
-            
+        translation_result = translate_code(request.code, request.target_language)
         raw_code = translation_result["code"]
         
         if request.mode == "polyglot":
@@ -86,10 +53,8 @@ async def translate_text_endpoint(
             "mode": request.mode,
             "target_language": lang_returned,
             "translated_code": final_code,
-            "tokens": translation_result.get("tokens", 0)
+            "tokens": translation_result["tokens"]
         }
-    except HTTPException as he:
-        raise he
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -97,16 +62,16 @@ async def translate_text_endpoint(
 @app.post("/api/v1/translate/file", tags=["Main"])
 async def translate_file_endpoint(
     target_language: str,
-    mode: str = Query("standard", pattern="^(standard|polyglot)$"),
+    mode: str = Query("standard", regex="^(standard|polyglot)$"),
     file: UploadFile = File(...),
-    api_key: str = Depends(get_api_key)
+    _apiKey: str = Depends(verify_groq_api_key)
 ):
     filename = file.filename
 
     # --- CASO A: ARCHIVO ÚNICO .JAVA ---
     if filename.endswith(".java"):
         try:
-            file_path, out_name, media_type = await process_single_java_file(file, target_language, mode, api_key=api_key)
+            file_path, out_name, media_type = await process_single_java_file(file, target_language, mode)
             return FileResponse(path=file_path, filename=out_name, media_type=media_type)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error traduciendo archivo Java: {str(e)}")
@@ -114,7 +79,7 @@ async def translate_file_endpoint(
     # --- CASO B: PROCESAMIENTO POR LOTES (.ZIP) ---
     elif filename.endswith(".zip"):
         try:
-            zip_out_path = await process_zip_batch(file, target_language, mode, api_key=api_key)
+            zip_out_path = await process_zip_batch(file, target_language, mode)
             return FileResponse(
                 path=zip_out_path, 
                 filename=f"lote_{mode}_{target_language}.zip", 

--- a/api/main.py
+++ b/api/main.py
@@ -1,29 +1,39 @@
-from fastapi import FastAPI, Depends, File, UploadFile, Query, HTTPException
+from fastapi import FastAPI, Depends, File, UploadFile, Query, HTTPException, Header
 from fastapi.responses import FileResponse
 
 # Componentes de arquitectura de la API
 from api.schemas import TranslationRequest
-from api.dependencies import verify_groq_api_key
 
 # Capa de Servicio descentralizada (Lógica de Negocio)
 from api.services import process_single_java_file, process_zip_batch
 from java_translator.translator import translate_code, build_polyglot_wrapper
 
+# Dependencia unificada: Ahora genera UN SOLO input limpio en Swagger
+async def get_api_key(
+    x_api_key: str = Header(None, alias="X-API-Key")
+):
+    if not x_api_key:
+        raise HTTPException(
+            status_code=401, 
+            detail="Falta credencial de autenticación. Incluya la cabecera 'X-API-Key'."
+        )
+    return x_api_key
+
 app = FastAPI(
-    title="B4B3L - Polyglot & Standard Translator API",
-    version="1.0.0",
+    title="B4B3L - Polyglot & Multi-Provider Standard Translator API",
+    version="1.1.0",
     description = """
-API del motor **B4B3L** para la traducción avanzada de código Java.
+API del motor **B4B3L** para la traducción avanzada de código Java con soporte multi-proveedor.
 
 ### 🌐 Endpoints Disponibles
 * **Texto (`/text`):** Traduce cadenas de código Java enviadas en formato JSON.
-* **Archivos/Lotes (`/file`):** Traduce archivos individuales `.java` o carpetas completas en lotes mediante archivos `.zip` (preservando la estructura original).
+* **Archivos/Lotes (`/file`):** Traduce archivos individuales `.java` o carpetas completas en lotes mediante archivos `.zip`.
 
 ### 🔄 Modos de Operación
 * `standard`: Devuelve el código limpio traducido directamente al lenguaje destino (`python` o `javascript`).
 * `polyglot`: Devuelve una clase ejecutable Java híbrida estructurada para el entorno **GraalVM Polyglot API**.
 
-⚠️ *Requiere autenticación mediante la cabecera **X-Groq-API-Key**.*
+⚠️ *Requieres autenticación mediante la cabecera **X-API-Key** (acepta tokens de Groq, OpenAI, Gemini y Anthropic).*
 """,
     swagger_ui_parameters={"defaultModelsExpandDepth": -1}
 )
@@ -32,13 +42,18 @@ API del motor **B4B3L** para la traducción avanzada de código Java.
 @app.post("/api/v1/translate/text", tags=["Main"])
 async def translate_text_endpoint(
     request: TranslationRequest, 
-    _apiKey: str = Depends(verify_groq_api_key)
+    api_key: str = Depends(get_api_key)
 ):
     if request.mode not in ["standard", "polyglot"]:
         raise HTTPException(status_code=400, detail="El parámetro 'mode' debe ser 'standard' o 'polyglot'.")
     
     try:
-        translation_result = translate_code(request.code, request.target_language)
+        # Pasamos la api_key dinámicamente al traductor polimórfico
+        translation_result = translate_code(request.code, request.target_language, api_key=api_key)
+        
+        if "error" in translation_result:
+            raise HTTPException(status_code=400, detail=translation_result["error"])
+            
         raw_code = translation_result["code"]
         
         if request.mode == "polyglot":
@@ -53,8 +68,10 @@ async def translate_text_endpoint(
             "mode": request.mode,
             "target_language": lang_returned,
             "translated_code": final_code,
-            "tokens": translation_result["tokens"]
+            "tokens": translation_result.get("tokens", 0)
         }
+    except HTTPException as he:
+        raise he
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -62,16 +79,16 @@ async def translate_text_endpoint(
 @app.post("/api/v1/translate/file", tags=["Main"])
 async def translate_file_endpoint(
     target_language: str,
-    mode: str = Query("standard", regex="^(standard|polyglot)$"),
+    mode: str = Query("standard", pattern="^(standard|polyglot)$"),
     file: UploadFile = File(...),
-    _apiKey: str = Depends(verify_groq_api_key)
+    api_key: str = Depends(get_api_key)
 ):
     filename = file.filename
 
     # --- CASO A: ARCHIVO ÚNICO .JAVA ---
     if filename.endswith(".java"):
         try:
-            file_path, out_name, media_type = await process_single_java_file(file, target_language, mode)
+            file_path, out_name, media_type = await process_single_java_file(file, target_language, mode, api_key=api_key)
             return FileResponse(path=file_path, filename=out_name, media_type=media_type)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error traduciendo archivo Java: {str(e)}")
@@ -79,7 +96,7 @@ async def translate_file_endpoint(
     # --- CASO B: PROCESAMIENTO POR LOTES (.ZIP) ---
     elif filename.endswith(".zip"):
         try:
-            zip_out_path = await process_zip_batch(file, target_language, mode)
+            zip_out_path = await process_zip_batch(file, target_language, mode, api_key=api_key)
             return FileResponse(
                 path=zip_out_path, 
                 filename=f"lote_{mode}_{target_language}.zip", 

--- a/api/main.py
+++ b/api/main.py
@@ -48,8 +48,8 @@ async def translate_text_endpoint(
         raise HTTPException(status_code=400, detail="El parámetro 'mode' debe ser 'standard' o 'polyglot'.")
     
     try:
-        # Pasamos la api_key dinámicamente al traductor polimórfico
-        translation_result = translate_code(request.code, request.target_language, api_key=api_key)
+        # Pasamos api_key y mode dinámicamente al traductor polimórfico
+        translation_result = translate_code(request.code, request.target_language, api_key=api_key, mode=request.mode)
         
         if "error" in translation_result:
             raise HTTPException(status_code=400, detail=translation_result["error"])

--- a/api/services.py
+++ b/api/services.py
@@ -22,23 +22,24 @@ async def process_single_java_file(file: UploadFile, target_language: str, mode:
     """
     class_name = Path(file.filename).stem
     content = await file.read()
-    
-    # CORRECCIÓN: Ahora pasamos la api_key recibida desde el endpoint
-    translation_result = translate_code(content.decode("utf-8"), target_language, api_key=api_key)
+
+    # Pasamos mode para que el LLM use el prompt correcto (standard vs polyglot)
+    translation_result = translate_code(content.decode("utf-8"), target_language, api_key=api_key, mode=mode)
     raw_code = translation_result["code"]
-    
+
     if mode == "polyglot":
         codigo_final = build_polyglot_wrapper(class_name, target_language, raw_code)
         output_filename = f"{class_name}Poliglota.java"
         media_type = "text/x-java-source"
     else:
+        # En modo standard, raw_code ya es código plano limpio
         codigo_final = raw_code
         output_filename = f"{class_name}{get_file_extension(target_language)}"
         media_type = "text/plain"
-    
+
     tmp_output_path = TMP_DIR / output_filename
     tmp_output_path.write_text(codigo_final, encoding="utf-8")
-    
+
     return tmp_output_path, output_filename, media_type
 
 
@@ -74,79 +75,19 @@ async def process_zip_batch(file: UploadFile, target_language: str, mode: str, a
         for java_file_path in java_files:
             class_name = java_file_path.stem
             java_code = java_file_path.read_text(encoding="utf-8")
-            
-            # CORRECCIÓN: Pasamos la api_key a cada traducción del lote
-            translation_result = translate_code(java_code, target_language, api_key=api_key)
+
+            # Pasamos mode para seleccionar el prompt y post-procesamiento correctos
+            translation_result = translate_code(java_code, target_language, api_key=api_key, mode=mode)
             raw_code = translation_result["code"]
-            
+
             if mode == "polyglot":
                 codigo_final = build_polyglot_wrapper(class_name, target_language, raw_code)
                 new_name = f"{class_name}Poliglota.java"
             else:
+                # En modo standard, raw_code ya es código plano limpio
                 codigo_final = raw_code
                 new_name = f"{class_name}{get_file_extension(target_language)}"
-            
-            # Replicar la estructura de carpetas original en el output
-            relative_path = java_file_path.relative_to(extract_dir)
-            out_file_path = (output_dir / relative_path).with_name(new_name)
-            out_file_path.parent.mkdir(parents=True, exist_ok=True)
-            out_file_path.write_text(codigo_final, encoding="utf-8")
 
-        # Comprimir resultados
-        with zipfile.ZipFile(zip_out_path, 'w', zipfile.ZIP_DEFLATED) as zip_out:
-            for file_to_zip in output_dir.glob("**/*"):
-                if file_to_zip.is_file():
-                    zip_out.write(file_to_zip, file_to_zip.relative_to(output_dir))
-
-        return zip_out_path
-
-    finally:
-        # Limpieza absoluta de temporales locales de este hilo/petición
-        if extract_dir.exists(): shutil.rmtree(extract_dir)
-        if output_dir.exists(): shutil.rmtree(output_dir)
-        if zip_in_path.exists(): os.remove(zip_in_path)
-    """
-    Descomprime un archivo ZIP, traduce todos los archivos .java internos
-    respetando el árbol de directorios y empaqueta el resultado en un nuevo ZIP.
-    Retorna la ruta del archivo ZIP resultante.
-    """
-    upload_id = os.urandom(4).hex()
-    extract_dir = TMP_DIR / f"extract_{upload_id}"
-    output_dir = TMP_DIR / f"output_{upload_id}"
-    extract_dir.mkdir()
-    output_dir.mkdir()
-
-    zip_in_path = TMP_DIR / f"{upload_id}_{file.filename}"
-    zip_out_path = TMP_DIR / f"resultado_{upload_id}.zip"
-
-    try:
-        # Guardar ZIP entrante
-        with open(zip_in_path, "wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
-
-        # Extraer contenido
-        with zipfile.ZipFile(zip_in_path, 'r') as zip_ref:
-            zip_ref.extractall(extract_dir)
-
-        java_files = list(extract_dir.glob("**/*.java"))
-        if not java_files:
-            raise HTTPException(status_code=400, detail="No hay archivos .java dentro del archivo ZIP provisto.")
-
-        # Procesar lote iterativamente
-        for java_file_path in java_files:
-            class_name = java_file_path.stem
-            java_code = java_file_path.read_text(encoding="utf-8")
-            
-            translation_result = translate_code(java_code, target_language)
-            raw_code = translation_result["code"]
-            
-            if mode == "polyglot":
-                codigo_final = build_polyglot_wrapper(class_name, target_language, raw_code)
-                new_name = f"{class_name}Poliglota.java"
-            else:
-                codigo_final = raw_code
-                new_name = f"{class_name}{get_file_extension(target_language)}"
-            
             # Replicar la estructura de carpetas original en el output
             relative_path = java_file_path.relative_to(extract_dir)
             out_file_path = (output_dir / relative_path).with_name(new_name)

--- a/api/services.py
+++ b/api/services.py
@@ -15,7 +15,7 @@ def get_file_extension(target_language: str) -> str:
     return ".py" if target_language.lower() == "python" else ".js"
 
 
-async def process_single_java_file(file: UploadFile, target_language: str, mode: str, api_key: str = None) -> tuple[Path, str, str]:
+async def process_single_java_file(file: UploadFile, target_language: str, mode: str) -> tuple[Path, str, str]:
     """
     Procesa, traduce y empaqueta un único archivo .java.
     Retorna una tupla con: (ruta_del_archivo_temporal, nombre_salida, media_type)
@@ -23,8 +23,8 @@ async def process_single_java_file(file: UploadFile, target_language: str, mode:
     class_name = Path(file.filename).stem
     content = await file.read()
     
-    # CORRECCIÓN: Ahora pasamos la api_key recibida desde el endpoint
-    translation_result = translate_code(content.decode("utf-8"), target_language, api_key=api_key)
+    # Traducción
+    translation_result = translate_code(content.decode("utf-8"), target_language)
     raw_code = translation_result["code"]
     
     if mode == "polyglot":
@@ -42,69 +42,7 @@ async def process_single_java_file(file: UploadFile, target_language: str, mode:
     return tmp_output_path, output_filename, media_type
 
 
-async def process_zip_batch(file: UploadFile, target_language: str, mode: str, api_key: str = None) -> Path:
-    """
-    Descomprime un archivo ZIP, traduce todos los archivos .java internos
-    respetando el árbol de directorios y empaqueta el resultado en un nuevo ZIP.
-    Retorna la ruta del archivo ZIP resultante.
-    """
-    upload_id = os.urandom(4).hex()
-    extract_dir = TMP_DIR / f"extract_{upload_id}"
-    output_dir = TMP_DIR / f"output_{upload_id}"
-    extract_dir.mkdir()
-    output_dir.mkdir()
-
-    zip_in_path = TMP_DIR / f"{upload_id}_{file.filename}"
-    zip_out_path = TMP_DIR / f"resultado_{upload_id}.zip"
-
-    try:
-        # Guardar ZIP entrante
-        with open(zip_in_path, "wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
-
-        # Extraer contenido
-        with zipfile.ZipFile(zip_in_path, 'r') as zip_ref:
-            zip_ref.extractall(extract_dir)
-
-        java_files = list(extract_dir.glob("**/*.java"))
-        if not java_files:
-            raise HTTPException(status_code=400, detail="No hay archivos .java dentro del archivo ZIP provisto.")
-
-        # Procesar lote iterativamente
-        for java_file_path in java_files:
-            class_name = java_file_path.stem
-            java_code = java_file_path.read_text(encoding="utf-8")
-            
-            # CORRECCIÓN: Pasamos la api_key a cada traducción del lote
-            translation_result = translate_code(java_code, target_language, api_key=api_key)
-            raw_code = translation_result["code"]
-            
-            if mode == "polyglot":
-                codigo_final = build_polyglot_wrapper(class_name, target_language, raw_code)
-                new_name = f"{class_name}Poliglota.java"
-            else:
-                codigo_final = raw_code
-                new_name = f"{class_name}{get_file_extension(target_language)}"
-            
-            # Replicar la estructura de carpetas original en el output
-            relative_path = java_file_path.relative_to(extract_dir)
-            out_file_path = (output_dir / relative_path).with_name(new_name)
-            out_file_path.parent.mkdir(parents=True, exist_ok=True)
-            out_file_path.write_text(codigo_final, encoding="utf-8")
-
-        # Comprimir resultados
-        with zipfile.ZipFile(zip_out_path, 'w', zipfile.ZIP_DEFLATED) as zip_out:
-            for file_to_zip in output_dir.glob("**/*"):
-                if file_to_zip.is_file():
-                    zip_out.write(file_to_zip, file_to_zip.relative_to(output_dir))
-
-        return zip_out_path
-
-    finally:
-        # Limpieza absoluta de temporales locales de este hilo/petición
-        if extract_dir.exists(): shutil.rmtree(extract_dir)
-        if output_dir.exists(): shutil.rmtree(output_dir)
-        if zip_in_path.exists(): os.remove(zip_in_path)
+async def process_zip_batch(file: UploadFile, target_language: str, mode: str) -> Path:
     """
     Descomprime un archivo ZIP, traduce todos los archivos .java internos
     respetando el árbol de directorios y empaqueta el resultado en un nuevo ZIP.

--- a/api/services.py
+++ b/api/services.py
@@ -15,7 +15,7 @@ def get_file_extension(target_language: str) -> str:
     return ".py" if target_language.lower() == "python" else ".js"
 
 
-async def process_single_java_file(file: UploadFile, target_language: str, mode: str) -> tuple[Path, str, str]:
+async def process_single_java_file(file: UploadFile, target_language: str, mode: str, api_key: str = None) -> tuple[Path, str, str]:
     """
     Procesa, traduce y empaqueta un único archivo .java.
     Retorna una tupla con: (ruta_del_archivo_temporal, nombre_salida, media_type)
@@ -23,8 +23,8 @@ async def process_single_java_file(file: UploadFile, target_language: str, mode:
     class_name = Path(file.filename).stem
     content = await file.read()
     
-    # Traducción
-    translation_result = translate_code(content.decode("utf-8"), target_language)
+    # CORRECCIÓN: Ahora pasamos la api_key recibida desde el endpoint
+    translation_result = translate_code(content.decode("utf-8"), target_language, api_key=api_key)
     raw_code = translation_result["code"]
     
     if mode == "polyglot":
@@ -42,7 +42,69 @@ async def process_single_java_file(file: UploadFile, target_language: str, mode:
     return tmp_output_path, output_filename, media_type
 
 
-async def process_zip_batch(file: UploadFile, target_language: str, mode: str) -> Path:
+async def process_zip_batch(file: UploadFile, target_language: str, mode: str, api_key: str = None) -> Path:
+    """
+    Descomprime un archivo ZIP, traduce todos los archivos .java internos
+    respetando el árbol de directorios y empaqueta el resultado en un nuevo ZIP.
+    Retorna la ruta del archivo ZIP resultante.
+    """
+    upload_id = os.urandom(4).hex()
+    extract_dir = TMP_DIR / f"extract_{upload_id}"
+    output_dir = TMP_DIR / f"output_{upload_id}"
+    extract_dir.mkdir()
+    output_dir.mkdir()
+
+    zip_in_path = TMP_DIR / f"{upload_id}_{file.filename}"
+    zip_out_path = TMP_DIR / f"resultado_{upload_id}.zip"
+
+    try:
+        # Guardar ZIP entrante
+        with open(zip_in_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+
+        # Extraer contenido
+        with zipfile.ZipFile(zip_in_path, 'r') as zip_ref:
+            zip_ref.extractall(extract_dir)
+
+        java_files = list(extract_dir.glob("**/*.java"))
+        if not java_files:
+            raise HTTPException(status_code=400, detail="No hay archivos .java dentro del archivo ZIP provisto.")
+
+        # Procesar lote iterativamente
+        for java_file_path in java_files:
+            class_name = java_file_path.stem
+            java_code = java_file_path.read_text(encoding="utf-8")
+            
+            # CORRECCIÓN: Pasamos la api_key a cada traducción del lote
+            translation_result = translate_code(java_code, target_language, api_key=api_key)
+            raw_code = translation_result["code"]
+            
+            if mode == "polyglot":
+                codigo_final = build_polyglot_wrapper(class_name, target_language, raw_code)
+                new_name = f"{class_name}Poliglota.java"
+            else:
+                codigo_final = raw_code
+                new_name = f"{class_name}{get_file_extension(target_language)}"
+            
+            # Replicar la estructura de carpetas original en el output
+            relative_path = java_file_path.relative_to(extract_dir)
+            out_file_path = (output_dir / relative_path).with_name(new_name)
+            out_file_path.parent.mkdir(parents=True, exist_ok=True)
+            out_file_path.write_text(codigo_final, encoding="utf-8")
+
+        # Comprimir resultados
+        with zipfile.ZipFile(zip_out_path, 'w', zipfile.ZIP_DEFLATED) as zip_out:
+            for file_to_zip in output_dir.glob("**/*"):
+                if file_to_zip.is_file():
+                    zip_out.write(file_to_zip, file_to_zip.relative_to(output_dir))
+
+        return zip_out_path
+
+    finally:
+        # Limpieza absoluta de temporales locales de este hilo/petición
+        if extract_dir.exists(): shutil.rmtree(extract_dir)
+        if output_dir.exists(): shutil.rmtree(output_dir)
+        if zip_in_path.exists(): os.remove(zip_in_path)
     """
     Descomprime un archivo ZIP, traduce todos los archivos .java internos
     respetando el árbol de directorios y empaqueta el resultado en un nuevo ZIP.

--- a/java_translator/prompts.py
+++ b/java_translator/prompts.py
@@ -1,7 +1,12 @@
 # prompts.py
 from java_translator.config import TARGET_NAMES, SUPPORTED_TARGETS
 
-SYSTEM_PROMPTS = {
+# ─────────────────────────────────────────────────────────────────────────────
+# PROMPTS MODO POLYGLOT
+# Instrucciones para generar código en formato de cadenas concatenadas de Java.
+# Este formato es exclusivo del envoltorio GraalVM Polyglot API.
+# ─────────────────────────────────────────────────────────────────────────────
+SYSTEM_PROMPTS_POLYGLOT = {
     "python": """Eres un experto en Java y Python. Tu tarea es traducir código Java a Python idiomático.
 
 Reglas estrictas:
@@ -28,17 +33,96 @@ Reglas estrictas:
 - Devuelve SOLO las líneas de string de Java, sin explicaciones, sin bloques markdown, ni la declaración del contexto."""
 }
 
-USER_PROMPT_TEMPLATE = "Traduce este código Java a {target_lang} formateado como un bloque String continuo para Java:\n\n```java\n{java_code}\n```"
+# ─────────────────────────────────────────────────────────────────────────────
+# PROMPTS MODO STANDARD
+# Instrucciones para generar código fuente limpio y ejecutable en el lenguaje
+# destino, sin ningún formato especial de Java ni concatenaciones.
+# ─────────────────────────────────────────────────────────────────────────────
+SYSTEM_PROMPTS_STANDARD = {
+    "python": """Eres un experto en Java y Python. Tu tarea es traducir código Java a Python idiomático.
 
-def get_system_prompt(target_lang: str) -> str:
-    """Retorna el prompt de sistema para el lenguaje destino."""
-    if target_lang not in SYSTEM_PROMPTS:
+Reglas estrictas:
+- Traduce la LÓGICA, no solo la sintaxis palabra por palabra.
+- Usa tipos y estructuras de Python (list, dict, set en vez de ArrayList, HashMap, HashSet).
+- Reemplaza System.out.println con print().
+- Convierte clases con solo métodos estáticos en funciones de módulo si aplica.
+- Usa snake_case para variables y funciones (Java usa camelCase).
+- Omite getters/setters verbosos: usa @property o atributos directos.
+- Maneja excepciones con try/except en vez de try/catch.
+
+FORMATO DE SALIDA OBLIGATORIO:
+- Devuelve ÚNICAMENTE el código Python traducido en texto plano.
+- NO uses formato de cadenas concatenadas de Java. NO envuelvas líneas entre comillas ni uses el operador +.
+- NO incluyas bloques de código Markdown (no uses ```python ni ```).
+- NO agregues explicaciones, comentarios adicionales ni texto introductorio.
+- El resultado debe ser código Python directamente ejecutable, con saltos de línea normales.""",
+
+    "javascript": """Eres un experto en Java y JavaScript moderno (ES2022+). Tu tarea es traducir código Java a JavaScript idiomático.
+
+Reglas estrictas:
+- Usa const y let, nunca var.
+- Convierte ArrayList → Array, HashMap → Map, HashSet → Set.
+- Usa clases ES6 para POO, con constructor() en vez de constructores Java.
+- System.out.println → console.log.
+- Maneja asincronía con async/await si hay I/O.
+- Usa template literals en vez de concatenación de strings.
+
+FORMATO DE SALIDA OBLIGATORIO:
+- Devuelve ÚNICAMENTE el código JavaScript traducido en texto plano.
+- NO uses formato de cadenas concatenadas de Java. NO envuelvas líneas entre comillas ni uses el operador + al final de cada línea.
+- NO incluyas bloques de código Markdown (no uses ```javascript ni ```).
+- NO agregues explicaciones, comentarios adicionales ni texto introductorio.
+- El resultado debe ser código JavaScript directamente ejecutable, con saltos de línea normales."""
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PLANTILLAS DE PROMPTS DE USUARIO
+# ─────────────────────────────────────────────────────────────────────────────
+USER_PROMPT_TEMPLATE_POLYGLOT = (
+    "Traduce este código Java a {target_lang} formateado como un bloque String continuo para Java:\n\n"
+    "```java\n{java_code}\n```"
+)
+
+USER_PROMPT_TEMPLATE_STANDARD = (
+    "Traduce este código Java a {target_lang}. "
+    "Devuelve SOLO el código {target_lang} limpio y ejecutable, sin ningún formato extra:\n\n"
+    "```java\n{java_code}\n```"
+)
+
+
+def get_system_prompt(target_lang: str, mode: str = "polyglot") -> str:
+    """Retorna el prompt de sistema adecuado al lenguaje destino y al modo de traducción.
+
+    Args:
+        target_lang: Lenguaje destino (ej. 'python', 'javascript').
+        mode: Modo de operación — 'standard' para código limpio, 'polyglot' para
+              el envoltorio GraalVM con cadenas concatenadas de Java.
+
+    Returns:
+        El string del prompt de sistema correspondiente.
+    """
+    prompts = SYSTEM_PROMPTS_STANDARD if mode == "standard" else SYSTEM_PROMPTS_POLYGLOT
+    if target_lang not in prompts:
         raise ValueError(f"Lenguaje no soportado: '{target_lang}'. Usa {list(SUPPORTED_TARGETS.keys())}")
-    return SYSTEM_PROMPTS[target_lang]
+    return prompts[target_lang]
 
-def get_user_prompt(java_code: str, target_lang: str) -> str:
-    """Construye el mensaje de usuario con el código Java."""
-    return USER_PROMPT_TEMPLATE.format(
+
+def get_user_prompt(java_code: str, target_lang: str, mode: str = "polyglot") -> str:
+    """Construye el mensaje de usuario con el código Java.
+
+    Args:
+        java_code: Código fuente Java a traducir.
+        target_lang: Lenguaje destino (ej. 'python', 'javascript').
+        mode: Modo de operación — 'standard' o 'polyglot'.
+
+    Returns:
+        El string del mensaje de usuario formateado.
+    """
+    template = (
+        USER_PROMPT_TEMPLATE_STANDARD if mode == "standard"
+        else USER_PROMPT_TEMPLATE_POLYGLOT
+    )
+    return template.format(
         target_lang=TARGET_NAMES.get(target_lang, target_lang),
         java_code=java_code
     )

--- a/java_translator/translator.py
+++ b/java_translator/translator.py
@@ -1,4 +1,5 @@
 import os
+import re
 from dotenv import load_dotenv
 from groq import Groq
 from openai import OpenAI
@@ -46,20 +47,72 @@ def _clean_markdown(code_text: str) -> str:
         cleaned = "\n".join(lines[1:-1]).strip()
     return cleaned
 
-def translate_code(java_code: str, target_language: str, api_key: str = None) -> dict:
+def clean_standard_output(code: str) -> str:
+    """Sanitiza la salida del LLM en modo 'standard' para garantizar código plano.
+
+    Elimina:
+    - Bloques de código Markdown (```lang ... ```)
+    - Formato de comillas y concatenaciones tipo Java (ej. "def sumar():\\n" +)
+    - Saltos de línea o comillas escapadas explícitamente (\\n, \\")
+
+    Args:
+        code: Texto devuelto por el LLM.
+
+    Returns:
+        Código fuente limpio como string plano con saltos de línea normales.
+    """
+    if not code:
+        return ""
+
+    # 1. Remover bloques Markdown (```lang\n...\n```)
+    code = re.sub(r"```[a-zA-Z]*\n?", "", code)
+    code = re.sub(r"```", "", code)
+
+    stripped = code.strip()
+
+    # 2. Si el texto viene envuelto en formato de concatenación de Java
+    #    (ej. "def sumar():\n" + o líneas rodeadas por comillas con signo +)
+    if '"+' in stripped or '+\n"' in stripped or (stripped.startswith('"') and ('+' in stripped or stripped.endswith('"'))):
+        clean_lines = []
+        for line in stripped.splitlines():
+            l = line.strip()
+            # Eliminar comilla inicial
+            l = re.sub(r'^\s*"', '', l)
+            # Eliminar comilla final, salto de línea escapado y signo + si existen
+            l = re.sub(r'(?:\\n)?\s*"\s*\+?\s*$', '', l)
+            clean_lines.append(l)
+        stripped = "\n".join(clean_lines)
+
+    # 3. Reemplazar saltos de línea y comillas escapadas explícitas si quedaron literales
+    stripped = stripped.replace("\\n", "\n").replace('\\"', '"')
+
+    return stripped.strip()
+
+
+def translate_code(java_code: str, target_language: str, api_key: str = None, mode: str = "polyglot") -> dict:
     """
     Traduce código Java a un lenguaje destino soportando múltiples proveedores de manera dinámica.
     Detecta automáticamente el proveedor basado en el prefijo de la API Key.
+
+    Args:
+        java_code: Código fuente Java a traducir.
+        target_language: Lenguaje destino (ej. 'python', 'javascript').
+        api_key: API Key del proveedor LLM. Si es None, se lee del entorno.
+        mode: Modo de traducción — 'standard' para código plano ejecutable,
+              'polyglot' para cadenas concatenadas de Java (envoltorio GraalVM).
+
+    Returns:
+        Diccionario con claves 'code' (str) y 'tokens' (dict) o 'error' (str).
     """
     # 1. Recuperar la API Key (de los parámetros o del entorno)
     key = api_key or os.getenv("GROQ_API_KEY") or os.getenv("OPENAI_API_KEY")
     if not key:
         raise ValueError("No se proporcionó ninguna API Key válida.")
 
-    # 2. Preparar los prompts estructurados del proyecto
-    system_prompt = get_system_prompt(target_language)
-    user_prompt = get_user_prompt(java_code, target_language)
-    
+    # 2. Preparar los prompts estructurados según el modo solicitado
+    system_prompt = get_system_prompt(target_language, mode=mode)
+    user_prompt = get_user_prompt(java_code, target_language, mode=mode)
+
     codigo_traducido = ""
     tokens_info = {"input": 0, "output": 0}
 
@@ -128,9 +181,14 @@ def translate_code(java_code: str, target_language: str, api_key: str = None) ->
                 "output": response.usage.completion_tokens
             }
 
-        # 4. Limpieza del código de salida y retorno estructurado
-        translated_clean = _clean_markdown(codigo_traducido)
-        
+        # 4. Post-procesamiento según el modo
+        if mode == "standard":
+            # Aplicar sanitización completa: elimina Markdown y concatenaciones Java
+            translated_clean = clean_standard_output(codigo_traducido)
+        else:
+            # Modo polyglot: solo limpiar posibles bloques Markdown sobrantes
+            translated_clean = _clean_markdown(codigo_traducido)
+
         return {
             "code": translated_clean,
             "tokens": tokens_info


### PR DESCRIPTION
Corrección en el formato del modo `standard`

Se corrigió un problema en el endpoint /translate donde el modo standard devolvía código traducido envuelto en concatenaciones de cadenas de Java (`"..." + \n`). Ahora el modo standard entrega código plano y ejecutable, reservando el envoltorio GraalVM únicamente para el modo polyglot.

Cambios realizados
Sanitización en java_translator/translator.py (clean_standard_output): Se mejoró el post-procesamiento con expresiones regulares para remover comillas, saltos de línea escapados (\n) y operadores + de concatenación.

Separación estricta de modos: 
  standard: Devuelve únicamente el código fuente traducido y limpio.
  polyglot: Devuelve la clase Java con la estructura GraalVM ('context.eval(...)`).

Pruebas realizadas
Validado vía Swagger UI (POST /translate) en ambos modos:
Standard: Respuesta verificada con sintaxis limpia en Python.
Polyglot: Respuesta verificada con la clase envoltorio ClaseDinamicaPoliglota.